### PR TITLE
Log server port when forwarding upstream

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -1992,8 +1992,12 @@ void log_query(unsigned int flags, char *name, union all_addr *addr, char *arg, 
 	    }
 	}
       else if (flags & (F_IPV4 | F_IPV6))
-	inet_ntop(flags & F_IPV4 ? AF_INET : AF_INET6,
-		  addr, daemon->addrbuff, ADDRSTRLEN);
+	{
+	  inet_ntop(flags & F_IPV4 ? AF_INET : AF_INET6,
+		    addr, daemon->addrbuff, ADDRSTRLEN);
+	  if (flags & F_SERVER) /* Append upstream server port if forwarding */
+	    sprintf(strchr(daemon->addrbuff, '\0'), "#%u", daemon->log_port);
+	}
       else
 	dest = arg;
     }

--- a/src/dnsmasq.h
+++ b/src/dnsmasq.h
@@ -1264,6 +1264,7 @@ extern struct daemon {
   /* file for packet dumps. */
   int dumpfd;
 #endif
+  in_port_t log_port;
 } *daemon;
 
 /* cache.c */

--- a/src/forward.c
+++ b/src/forward.c
@@ -122,9 +122,15 @@ static void set_outgoing_mark(struct frec *forward, int fd)
 static void log_query_mysockaddr(unsigned int flags, char *name, union mysockaddr *addr, char *arg, unsigned short type)
 {
   if (addr->sa.sa_family == AF_INET)
-    log_query(flags | F_IPV4, name, (union all_addr *)&addr->in.sin_addr, arg, type);
+    {
+      daemon->log_port = ntohs(addr->in.sin_port);
+      log_query(flags | F_IPV4, name, (union all_addr *)&addr->in.sin_addr, arg, type);
+    }
   else
-    log_query(flags | F_IPV6, name, (union all_addr *)&addr->in6.sin6_addr, arg, type);
+    {
+      daemon->log_port = ntohs(addr->in6.sin6_port);
+      log_query(flags | F_IPV6, name, (union all_addr *)&addr->in6.sin6_addr, arg, type);
+    }
 }
 
 static void server_send(struct server *server, int fd,

--- a/src/option.c
+++ b/src/option.c
@@ -5405,7 +5405,9 @@ void read_opts(int argc, char **argv, char *compile_opts)
   daemon = opt_malloc(sizeof(struct daemon));
   memset(daemon, 0, sizeof(struct daemon));
   daemon->namebuff = buff;
-  daemon->addrbuff = safe_malloc(ADDRSTRLEN);
+  /* Space for IP address plus port (used when logging 
+     upstream server forwarding) */
+  daemon->addrbuff = safe_malloc(ADDRSTRLEN + 10);
   
   /* Set defaults - everything else is zero or NULL */
   daemon->cachesize = CACHESIZ;


### PR DESCRIPTION
Log server port when forwarding upstream to avoid ambiguities when running multiple upstream destinations at the same IP but different ports. The port is already logged in other places, like after starting `dnsmasq`:

```
Nov 17 18:03:16 dnsmasq[123]: using nameserver 127.0.0.1#5001
Nov 17 18:03:16 dnsmasq[123]: using nameserver 127.0.0.1#5002 for domain network (no DNSSEC)
Nov 17 18:03:16 dnsmasq[123]: using nameserver 127.0.0.1#5003 for domain example2.com (no DNSSEC)
Nov 17 18:03:16 dnsmasq[123]: using nameserver 127.0.0.1#5004 for unqualified names (no DNSSEC)
```