### PR TITLE
Improve cache dump

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -1757,8 +1757,8 @@ void dump_cache(time_t now)
     {
       struct crec *cache ;
       int i;
-      my_syslog(LOG_INFO, "Host                           Address                                  Flags      Expires");
-      my_syslog(LOG_INFO, "------------------------------ ---------------------------------------- ---------  ------------------------");
+      my_syslog(LOG_INFO, "Host                           Address                                  Flags      Expires                  Source");
+      my_syslog(LOG_INFO, "------------------------------ ---------------------------------------- ---------- ------------------------ ------------");
     
       for (i=0; i<hash_size; i++)
 	for (cache = hash_table[i]; cache; cache = cache->hash_next)
@@ -1816,7 +1816,10 @@ void dump_cache(time_t now)
 	    else if (cache->flags & F_DNSKEY)
 	      t = "K";
 #endif
-	    p += sprintf(p, "%-40.40s %s%s%s%s%s%s%s%s%s  ", a, t,
+	    else /* non-terminal */
+	      t = "!";
+
+	    p += sprintf(p, "%-40.40s %s%s%s%s%s%s%s%s%s%s ", a, t,
 			 cache->flags & F_FORWARD ? "F" : " ",
 			 cache->flags & F_REVERSE ? "R" : " ",
 			 cache->flags & F_IMMORTAL ? "I" : " ",
@@ -1824,14 +1827,16 @@ void dump_cache(time_t now)
 			 cache->flags & F_NEG ? "N" : " ",
 			 cache->flags & F_NXDOMAIN ? "X" : " ",
 			 cache->flags & F_HOSTS ? "H" : " ",
+			 cache->flags & F_CONFIG ? "C" : " ",
 			 cache->flags & F_DNSSECOK ? "V" : " ");
 #ifdef HAVE_BROKEN_RTC
-	    p += sprintf(p, "%lu", cache->flags & F_IMMORTAL ? 0: (unsigned long)(cache->ttd - now));
+	    p += sprintf(p, "%-24lu", cache->flags & F_IMMORTAL ? 0: (unsigned long)(cache->ttd - now));
 #else
-	    p += sprintf(p, "%s", cache->flags & F_IMMORTAL ? "\n" : ctime(&(cache->ttd)));
-	    /* ctime includes trailing \n - eat it */
-	    *(p-1) = 0;
+	    p += sprintf(p, "%-24.24s", cache->flags & F_IMMORTAL ? "" : ctime(&(cache->ttd)));
 #endif
+	    if(cache->flags & (F_HOSTS | F_CONFIG) && cache->uid > 0)
+		p += sprintf(p, " %s", record_source(cache->uid));
+
 	    my_syslog(LOG_INFO, "%s", daemon->namebuff);
 	  }
     }

--- a/src/cache.c
+++ b/src/cache.c
@@ -1757,7 +1757,8 @@ void dump_cache(time_t now)
     {
       struct crec *cache ;
       int i;
-      my_syslog(LOG_INFO, "Host                                     Address                        Flags      Expires");
+      my_syslog(LOG_INFO, "Host                           Address                                  Flags      Expires");
+      my_syslog(LOG_INFO, "------------------------------ ---------------------------------------- ---------  ------------------------");
     
       for (i=0; i<hash_size; i++)
 	for (cache = hash_table[i]; cache; cache = cache->hash_next)


### PR DESCRIPTION
These patches improve the cache dump triggered by sending `SIGUSR1`.

1. The width of the host and address fields are 30 and 40 characters, respectively. Fix the header and add a head separation line to highlight how long the fields can be.
2. Add "!" as type for non-terminals, new flag "C" for config-provided and log source when applicable.

Before:
```
Host                                     Address                        Flags      Expires
imap.strato.de                 2a01:238:20a:202:54f0::1103              6F         Wed Dec 15 20:51:59 2021
imap.strato.de                 81.169.145.103                           4F         Wed Dec 15 20:51:59 2021
some-hostrecord                192.168.2.3                              4FRI   H
ip6-localhost                  ::1                                      6FRI   H
arpa                                                                     F I
<Root>                         20326   8   2                            SF I
```

Now:
```
Host                           Address                                  Flags      Expires                  Source
------------------------------ ---------------------------------------- ---------- ------------------------ ------------
imap.strato.de                 2a01:238:20a:202:54f0::1103              6F         Wed Dec 15 20:51:59 2021
imap.strato.de                 81.169.145.103                           4F         Wed Dec 15 20:51:59 2021
some-hostrecord                192.168.2.3                              4FRI   HC                           config
ip6-localhost                  ::1                                      6FRI   H                            /etc/hosts
arpa                                                                    !F I    C
<Root>                         20326   8   2                            SF I    C                           config
```