### PR TITLE
Log which interface is actually used when a different was configured

### DIFF
--- a/src/dnsmasq.h
+++ b/src/dnsmasq.h
@@ -632,7 +632,7 @@ struct irec {
   union mysockaddr addr;
   struct in_addr netmask; /* only valid for IPv4 */
   int tftp_ok, dhcp_ok, mtu, done, warned, dad, dns_auth, index, multicast_done, found, label;
-  char *name; 
+  char *name, *slabel;
   struct irec *next;
 };
 

--- a/src/network.c
+++ b/src/network.c
@@ -506,7 +506,7 @@ static int iface_allowed(struct iface_param *param, int if_index, char *label,
     }
   else
     for (tmp = daemon->dhcp_except; tmp; tmp = tmp->next)
-      if (tmp->name && wildcard_match(tmp->name, ifr.ifr_name))
+      if (tmp->name && wildcard_match(tmp->name, label))
 	{
 	  tftp_ok = 0;
 	  dhcp_ok = 0;
@@ -520,7 +520,7 @@ static int iface_allowed(struct iface_param *param, int if_index, char *label,
       /* dedicated tftp interface list */
       tftp_ok = 0;
       for (tmp = daemon->tftp_interfaces; tmp; tmp = tmp->next)
-	if (tmp->name && wildcard_match(tmp->name, ifr.ifr_name))
+	if (tmp->name && wildcard_match(tmp->name, label))
 	  tftp_ok = 1;
     }
 #endif

--- a/src/network.c
+++ b/src/network.c
@@ -544,9 +544,11 @@ static int iface_allowed(struct iface_param *param, int if_index, char *label,
       iface->done = iface->multicast_done = iface->warned = 0;
       iface->index = if_index;
       iface->label = is_label;
-      if ((iface->name = whine_malloc(strlen(ifr.ifr_name)+1)))
+      if ((iface->slabel = whine_malloc(strlen(label)+1)) &&
+          (iface->name = whine_malloc(strlen(ifr.ifr_name)+1)))
 	{
 	  strcpy(iface->name, ifr.ifr_name);
+	  strcpy(iface->slabel, label);
 	  iface->next = daemon->interfaces;
 	  daemon->interfaces = iface;
 	  return 1;
@@ -1221,7 +1223,7 @@ void warn_wild_labels(void)
 
   for (iface = daemon->interfaces; iface; iface = iface->next)
     if (iface->found && iface->name && iface->label)
-      my_syslog(LOG_WARNING, _("warning: using interface %s instead"), iface->name);
+      my_syslog(LOG_WARNING, _("warning: using interface %s instead of %s"), iface->name, iface->slabel);
 }
 
 void warn_int_names(void)


### PR DESCRIPTION
This is alternative PR to #5. In contrast to #5, this PR does not fix the bug of listening on both interfaces when asked only to listen on the alias interface (see other PR for details). Instead, it only adds logging for which interface is actually used when a different was configured.

I personally prefer #5 but want to be prepared if it is rejected because fixing the bug breaks backwards-compatibility in some edge-cases.