### PR TITLE
DNS flag day 2020: Minimum safe size is 1232

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -20,7 +20,7 @@
 #define TCP_MAX_QUERIES 100 /* Maximum number of queries per incoming TCP connection */
 #define TCP_BACKLOG 32  /* kernel backlog limit for TCP connections */
 #define EDNS_PKTSZ 4096 /* default max EDNS.0 UDP packet from RFC5625 */
-#define SAFE_PKTSZ 1280 /* "go anywhere" UDP packet size */
+#define SAFE_PKTSZ 1232 /* "go anywhere" UDP packet size, see https://dnsflagday.net/2020/ */
 #define KEYBLOCK_LEN 40 /* choose to minimise fragmentation when storing DNSSEC keys */
 #define DNSSEC_WORK 50 /* Max number of queries to validate one question */
 #define TIMEOUT 10     /* drop UDP queries after TIMEOUT seconds */


### PR DESCRIPTION
Minimum safe size is recommended to be 1232. See https://dnsflagday.net/2020/, relevant parts below:

> This year, we are focusing on problems with IP fragmentation of DNS packets.
>
> IP fragmentation is unreliable on the Internet today, and can cause transmission failures when large DNS messages are sent via UDP. Even when fragmentation does work, it may not be secure; it is theoretically possible to spoof parts of a fragmented DNS message, without easy detection at the receiving end.
>
> - Bonica R. et al, “IP Fragmentation Considered Fragile”, Work in Progress, July 2018
> - Huston G., “IPv6, Large UDP Packets and the DNS”, August 2017
> - Fujiwara K., “Measures against cache poisoning attacks using IP fragmentation in DNS”, May 2019
> - Fujiwara K. et al, “Avoid IP fragmentation in DNS”, September 2019
> 
> Recently, there was an paper and presentation Defragmenting DNS - Determining the optimal maximum UDP response size for DNS by Axel Koolhaas, and Tjeerd Slokker in collaboration with NLnet Labs that explored the real world data using the RIPE Atlas probes and the researchers suggested different values for IPv4 and IPv6 and in different scenarios. This is practical for the server operators that know their environment, and **the defaults in the DNS software should reflect the minimum safe size which is 1232.**

This PR reduces the minimum safe size to said 1232 bytes. Actually, the DNS flag day asks us to reduce `EDNS_PKTSZ` (currently `4096`) to ensure fragmentation will never happen, but I don't think we really want to do this given the steady growth in DNSSEC-enabled zones (see trend graphs on https://stats.dnssec-tools.org).