### PR TITLE
Also log upstream port for dnssec-retry

### DIFF
--- a/src/forward.c
+++ b/src/forward.c
@@ -527,8 +527,8 @@ static int forward_query(int udpfd, union mysockaddr *udpaddr,
 		}
 #ifdef HAVE_DNSSEC
 	      else
-		log_query_mysockaddr(F_NOEXTRA | F_DNSSEC, daemon->namebuff, &srv->addr,
-				     "dnssec-retry", (forward->flags & FREC_DNSKEY_QUERY) ? T_DNSKEY : T_DS);
+		log_query_mysockaddr(F_NOEXTRA | F_DNSSEC | F_SERVER, daemon->namebuff, &srv->addr,
+				     (forward->flags & FREC_DNSKEY_QUERY) ? "dnssec-retry[DNSKEY]" : "dnssec-retry[DS]", 0);
 #endif
 
 	      srv->queries++;


### PR DESCRIPTION
The current version of dnsmasq logs the upstream port like

```
Feb 21 22:02:18 dnsmasq[8991]: dnssec-query[DS] microsoft.net to 127.0.0.1#5053
```

when sending queries upstream. However, it is missing for dnssec-retry like

```
Feb 21 22:02:18 dnsmasq[8991]: dnssec-retry[DS] microsoft.net to 127.0.0.1
```

This is added by this patch implementing it in the same way as used elsewhere in the code.