### PR TITLE
Add run-time option to disable CHAOS TXT records

### DIFF
--- a/man/dnsmasq.8
+++ b/man/dnsmasq.8
@@ -2215,6 +2215,20 @@ exit 0
 
 and /share/ads-domains.gz containing a compressed
 list of ad server domains will save disk space with large ad-server blocklists.
+.TP
+.B --no-ident
+Do not respond to class CHAOS and type TXT in domain bind queries.
+
+Without this option being set, the cache statistics are also available in the
+DNS as answers to queries of class CHAOS and type TXT in domain bind. The domain
+names are cachesize.bind, insertions.bind, evictions.bind, misses.bind,
+hits.bind, auth.bind and servers.bind unless disabled at compile-time. An
+example command to query this, using the
+.B dig
+utility would be
+
+dig +short chaos txt cachesize.bind
+
 .SH CONFIG FILE
 At startup, dnsmasq reads
 .I /etc/dnsmasq.conf,
@@ -2264,15 +2278,6 @@ resulted in an error. In
 mode or when full logging is enabled (\fB--log-queries\fP), a complete dump of the
 contents of the cache is made. 
 
-The cache statistics are also available in the DNS as answers to 
-queries of class CHAOS and type TXT in domain bind. The domain names are cachesize.bind, insertions.bind, evictions.bind, 
-misses.bind, hits.bind, auth.bind and servers.bind. An example command to query this, using the 
-.B dig
-utility would be
-
-dig +short chaos txt cachesize.bind
-
-.PP 
 When it receives SIGUSR2 and it is logging direct to a file (see
 .B --log-facility
 ) 

--- a/src/dnsmasq.h
+++ b/src/dnsmasq.h
@@ -281,7 +281,8 @@ struct event_desc {
 #define OPT_STRIP_ECS      69
 #define OPT_STRIP_MAC      70
 #define OPT_NORR           71
-#define OPT_LAST           72
+#define OPT_NO_IDENT       72
+#define OPT_LAST           73
 
 #define OPTION_BITS (sizeof(unsigned int)*8)
 #define OPTION_SIZE ( (OPT_LAST/OPTION_BITS)+((OPT_LAST%OPTION_BITS)!=0) )

--- a/src/option.c
+++ b/src/option.c
@@ -185,6 +185,7 @@ struct myoption {
 #define LOPT_FAST_RETRY    376
 #define LOPT_STALE_CACHE   377
 #define LOPT_NORR          378
+#define LOPT_NO_IDENT      379
 
 #ifdef HAVE_GETOPT_LONG
 static const struct option opts[] =  
@@ -374,6 +375,7 @@ static const struct myoption opts[] =
     { "port-limit", 1, 0, LOPT_RANDPORT_LIM },
     { "fast-dns-retry", 2, 0, LOPT_FAST_RETRY },
     { "use-stale-cache", 2, 0 , LOPT_STALE_CACHE },
+    { "no-ident", 0, 0, LOPT_NO_IDENT },
     { NULL, 0, 0, 0 }
   };
 
@@ -570,6 +572,7 @@ static struct {
   { LOPT_UMBRELLA, ARG_ONE, "[=<optspec>]", gettext_noop("Send Cisco Umbrella identifiers including remote IP."), NULL },
   { LOPT_QUIET_TFTP, OPT_QUIET_TFTP, NULL, gettext_noop("Do not log routine TFTP."), NULL },
   { LOPT_NORR, OPT_NORR, NULL, gettext_noop("Suppress round-robin ordering of DNS records."), NULL },
+  { LOPT_NO_IDENT, OPT_NO_IDENT, NULL, gettext_noop("Do not add CHAOS TXT records."), NULL },
   { 0, 0, NULL, NULL, NULL }
 }; 
 
@@ -5757,21 +5760,6 @@ void read_opts(int argc, char **argv, char *compile_opts)
   daemon->randport_limit = 1;
   daemon->host_index = SRC_AH;
   
-#ifndef NO_ID
-  add_txt("version.bind", "dnsmasq-" VERSION, 0 );
-  add_txt("authors.bind", "Simon Kelley", 0);
-  add_txt("copyright.bind", COPYRIGHT, 0);
-  add_txt("cachesize.bind", NULL, TXT_STAT_CACHESIZE);
-  add_txt("insertions.bind", NULL, TXT_STAT_INSERTS);
-  add_txt("evictions.bind", NULL, TXT_STAT_EVICTIONS);
-  add_txt("misses.bind", NULL, TXT_STAT_MISSES);
-  add_txt("hits.bind", NULL, TXT_STAT_HITS);
-#ifdef HAVE_AUTH
-  add_txt("auth.bind", NULL, TXT_STAT_AUTH);
-#endif
-  add_txt("servers.bind", NULL, TXT_STAT_SERVERS);
-#endif
-  
   /* See comment above make_servers(). Optimises server-read code. */
   mark_servers(0);
   
@@ -5868,6 +5856,25 @@ void read_opts(int argc, char **argv, char *compile_opts)
     }
   else
     one_file(CONFFILE, LOPT_CONF_OPT);
+
+  /* Add TXT records if wanted */
+#ifndef NO_ID
+  if (!option_bool(OPT_NO_IDENT))
+    {
+      add_txt("version.bind", "dnsmasq-" VERSION, 0 );
+      add_txt("authors.bind", "Simon Kelley", 0);
+      add_txt("copyright.bind", COPYRIGHT, 0);
+      add_txt("cachesize.bind", NULL, TXT_STAT_CACHESIZE);
+      add_txt("insertions.bind", NULL, TXT_STAT_INSERTS);
+      add_txt("evictions.bind", NULL, TXT_STAT_EVICTIONS);
+      add_txt("misses.bind", NULL, TXT_STAT_MISSES);
+      add_txt("hits.bind", NULL, TXT_STAT_HITS);
+#ifdef HAVE_AUTH
+      add_txt("auth.bind", NULL, TXT_STAT_AUTH);
+#endif
+      add_txt("servers.bind", NULL, TXT_STAT_SERVERS);
+    }
+#endif
 
   /* port might not be known when the address is parsed - fill in here */
   if (daemon->servers)


### PR DESCRIPTION
In 2016, dnsmasq got the option to prevent serving the server version as well as the statistics publicly. Compiling with -`DNO_ID` removes the entire `*.bind` info structure. This includes: version, author, copyright, cachesize, cache insertions, evictions, misses & hits, auth & servers. However, setting `-DNO_ID` requires a (re-)compilation from source.

This patch adds a new *run-time* option `--no-ident` to achieve the same without the need for recompiling.