### PR TITLE
Fix --rev-server option. 

### DIFF
--- a/src/option.c
+++ b/src/option.c
@@ -1159,6 +1159,9 @@ static char *domain_rev4(int from_file, char *server, struct in_addr *addr4, int
 	}
       else
 	{
+	  /* Always reset server as valid here, so we can add the same upstream
+	     server address multiple times for each x.y.z.in-addr.arpa  */
+	  sdetails.valid = 1;
 	  while (parse_server_next(&sdetails))
 	    {
 	      if ((string = parse_server_addr(&sdetails)))
@@ -1244,6 +1247,9 @@ static char *domain_rev6(int from_file, char *server, struct in6_addr *addr6, in
 	}
       else
 	{
+	  /* Always reset server as valid here, so we can add the same upstream
+	     server address multiple times for each x.y.z.ip6.arpa  */
+	  sdetails.valid = 1;
 	  while (parse_server_next(&sdetails))
 	    {
 	      if ((string = parse_server_addr(&sdetails)))


### PR DESCRIPTION
The `--rev-server` option is broken in the currently released version of `dnsmasq` for any non-dividable-by-8 CIDR subnets.

It was broken in 1db9943c6879c160a5fbef885d5ceadd3668b74d when resolving upstream servers by name was extended to `--rev-server` without accounting for the fact that re-using one and the same upstream server for each of the `x.y.z.in-addr.arpa` is actually a wanted feature.