### PR TITLE
Fix double free() corruption due to config

### DIFF
--- a/src/option.c
+++ b/src/option.c
@@ -1188,11 +1188,11 @@ static char *domain_rev4(int from_file, char *server, struct in_addr *addr4, int
 	      if (!add_update_server(flags, &serv_addr, &source_addr, interface, domain, NULL))
 		return  _("error");
 	    }
-
-	  if (sdetails.orig_hostinfo)
-	    freeaddrinfo(sdetails.orig_hostinfo);
 	}
     }
+
+    if (sdetails.orig_hostinfo)
+      freeaddrinfo(sdetails.orig_hostinfo);
   
   return NULL;
 }
@@ -1276,11 +1276,11 @@ static char *domain_rev6(int from_file, char *server, struct in6_addr *addr6, in
 	      if (!add_update_server(flags, &serv_addr, &source_addr, interface, domain, NULL))
 		return  _("error");
 	    }
-
-	  if (sdetails.orig_hostinfo)
-	    freeaddrinfo(sdetails.orig_hostinfo);
 	}
     }
+
+    if (sdetails.orig_hostinfo)
+      freeaddrinfo(sdetails.orig_hostinfo);
   
   return NULL;
 }


### PR DESCRIPTION
> Hey Simon,
> 
> the attached patch fixes a double free() corruption leading to a crash 
> during startup of dnsmasq. The crash can be reproduced by using a 
> rev-server addresses with a prefix length != {8,16,24,32}, e.g.
>
> `rev-server=192.168.0.0/25,home.mydomain.com`
> 
> The crash is caused by freeing too early (within the loop). The crash 
> does not happen for prefix lengths {8,16,24,32} as the loop runs only 
> once. However, for other prefixes, the loop runs more often (e.g. 128x 
> for /25 networks as above).
>
> Best,
> Dominik

Tracked here: https://lists.thekelleys.org.uk/pipermail/dnsmasq-discuss/2024q2/017606.html