### PR TITLE
Fix memcheck errors like "Syscall param  sendmsg(msg.msg_control) points to uninitialised byte(s)"

### DIFF
--- a/src/forward.c
+++ b/src/forward.c
@@ -35,7 +35,7 @@ int send_from(int fd, int nowild, char *packet, size_t len,
 	      union mysockaddr *to, union all_addr *source,
 	      unsigned int iface)
 {
-  struct msghdr msg;
+  struct msghdr msg = { 0 };
   struct iovec iov[1]; 
   union {
     struct cmsghdr align; /* this ensures alignment */
@@ -45,7 +45,7 @@ int send_from(int fd, int nowild, char *packet, size_t len,
     char control[CMSG_SPACE(sizeof(struct in_addr))];
 #endif
     char control6[CMSG_SPACE(sizeof(struct in6_pktinfo))];
-  } control_u;
+  } control_u = { 0 };
   
   iov[0].iov_base = packet;
   iov[0].iov_len = len;


### PR DESCRIPTION
Hey Simon,

another patch fixing a small memcheck error reported during Pi-hole 
testing. The error is caused in send_from() (forward.c) by handing a 
partially uninitialized stack variable to sendmsg() when nowild == false.

Full error output (example):

==1052839== Syscall param sendmsg(msg.msg_control) points to 
uninitialised byte(s)
==1052839== at 0x4B7199D: __libc_sendmsg (sendmsg.c:28)
==1052839== by 0x4B7199D: sendmsg (sendmsg.c:25)
==1052839== by 0x21EADB: send_from (forward.c:101)
==1052839== by 0x222551: receive_query (forward.c:1988)
==1052839== by 0x20FD6A: check_dns_listeners (dnsmasq.c:1886)
==1052839== by 0x2120EF: main (dnsmasq.c:1278)
==1052839== Location 0x1fff000098is 24bytes inside local var "control_u"
==1052839== declared at forward.c:49, in frame #1of thread 1
==1052839== Uninitialised value was created by a stack allocation
==1052839== at 0x21EA11: send_from (forward.c:38)

Note that the line-numbers are not necessarily 100% accurate. We have 
not noticed any abnormal behavior, however, fixing this reported error 
is easy enough.

Best,
Dominik

https://lists.thekelleys.org.uk/pipermail/dnsmasq-discuss/2024q3/017654.html